### PR TITLE
Fixed issue with Editor scripts not compiling

### DIFF
--- a/Editor/AlturaNFT.Editor.asmdef
+++ b/Editor/AlturaNFT.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "AlturaNFT.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:d67ea1a519fc84929a22ce035e0f8b15"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/AlturaNFT.Editor.asmdef.meta
+++ b/Editor/AlturaNFT.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ceb9ab0dbc555451289c2ed61b68b0c0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/InstallAlturaDependencies.cs
+++ b/Editor/InstallAlturaDependencies.cs
@@ -23,7 +23,7 @@ namespace AlturaNFT.Internal {
             SetSize(win);
         }
 
-        #region Scri[tinDefines
+        #region ScriptingDefines
         public static bool CheckScriptingDefine(string scriptingDefine)
         {
             BuildTargetGroup buildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;


### PR DESCRIPTION
Had an issue where Editor scripts weren't compiling due to this error:
![image](https://user-images.githubusercontent.com/6146752/189552003-7569edb8-1d33-44c5-bf60-53cf185f0a21.png)

Because the editor files were outside the assets folder in the root project on importing the package, this prevented any compilation process from triggering. Adding an assembly definition file into the editor folder of the package and making sure it only compiles on the "Editor" platform solved this.

After implementing this fix I was able to see the AlutraNFT tool option at the top:
![image](https://user-images.githubusercontent.com/6146752/189552077-92f3e3fa-85c9-41c3-bce4-01decd4deb9f.png)
